### PR TITLE
Hotfix to add proper handling of MaxMessageLength and NewLines to the bridge system.

### DIFF
--- a/src/net/dv8tion/discord/bridge/IrcConnection.java
+++ b/src/net/dv8tion/discord/bridge/IrcConnection.java
@@ -20,6 +20,8 @@ import org.pircbotx.hooks.events.MessageEvent;
 
 public class IrcConnection extends ListenerAdapter<PircBotX> implements EventListener
 {
+    public static final int MESSAGE_DELAY_AMOUNT = 250;
+
     private String identifier;
     private Thread botThread;
     private PircBotX bot;
@@ -29,7 +31,7 @@ public class IrcConnection extends ListenerAdapter<PircBotX> implements EventLis
         identifier = info.getIdentifier();
         Builder<PircBotX> builder = info.getIrcConfigBuilder();
         builder.addListener(this);
-        builder.setMessageDelay(250);  //TODO: Make this configurable.
+        builder.setMessageDelay(MESSAGE_DELAY_AMOUNT);
         bot = new PircBotX(builder.buildConfiguration());
         this.open();
     }

--- a/src/net/dv8tion/discord/bridge/endpoint/EndPoint.java
+++ b/src/net/dv8tion/discord/bridge/endpoint/EndPoint.java
@@ -1,5 +1,7 @@
 package net.dv8tion.discord.bridge.endpoint;
 
+import java.util.ArrayList;
+
 
 public abstract class EndPoint
 {
@@ -7,6 +9,7 @@ public abstract class EndPoint
     protected boolean connected;
 
     public abstract EndPointInfo toEndPointInfo();
+    public abstract int getMaxMessageLength();
     public abstract void sendMessage(String message);
     public abstract void sendMessage(EndPointMessage message);
 
@@ -26,8 +29,32 @@ public abstract class EndPoint
         this.connected = connected;
     }
 
-    public boolean isType(EndPointType connectionType)
+    public EndPointType getType()
     {
-        return this.connectionType.equals(connectionType);
+        return connectionType;
+    }
+
+    public ArrayList<String> divideMessageForSending(String message)
+    {
+        ArrayList<String> messageParts = new ArrayList<String>();
+        while (message.length() >  getMaxMessageLength())
+        {
+            //Finds where the last complete word is in the IrcConnection.MAX_LINE_LENGTH length character string.
+            int lastSpace = message.substring(0, getMaxMessageLength()).lastIndexOf(" ");
+            String smallerLine;
+            if (lastSpace != -1)
+            {
+                smallerLine = message.substring(0, lastSpace);
+                message = message.substring(lastSpace + 1);   //Don't include the space.
+            }
+            else
+            {
+                smallerLine = message.substring(0, getMaxMessageLength());
+                message = message.substring(getMaxMessageLength());
+            }
+            messageParts.add(smallerLine);
+        }
+        messageParts.add(message);
+        return messageParts;
     }
 }

--- a/src/net/dv8tion/discord/bridge/endpoint/types/DiscordEndPoint.java
+++ b/src/net/dv8tion/discord/bridge/endpoint/types/DiscordEndPoint.java
@@ -10,6 +10,8 @@ import net.dv8tion.discord.bridge.endpoint.EndPointType;
 
 public class DiscordEndPoint extends EndPoint
 {
+    public static final int MAX_MESSAGE_LENGTH = 2000;
+
     private String serverId;
     private String groupId;
 
@@ -47,6 +49,12 @@ public class DiscordEndPoint extends EndPoint
     }
 
     @Override
+    public int getMaxMessageLength()
+    {
+        return MAX_MESSAGE_LENGTH;
+    }
+
+    @Override
     public void sendMessage(String message)
     {
         if (!connected)
@@ -65,8 +73,8 @@ public class DiscordEndPoint extends EndPoint
                 getGroup().sendMessage(message.getDiscordMessage());
                 break;
             default:
-                sendMessage(String.format("<%s> %s", message.getSenderName(), message.getMessage()));
+                for (String segment : this.divideMessageForSending(message.getMessage()))
+                    sendMessage(String.format("<%s> %s", message.getSenderName(), segment));
         }
     }
-
 }

--- a/src/net/dv8tion/discord/bridge/endpoint/types/IrcEndPoint.java
+++ b/src/net/dv8tion/discord/bridge/endpoint/types/IrcEndPoint.java
@@ -10,6 +10,8 @@ import org.pircbotx.Channel;
 
 public class IrcEndPoint extends EndPoint
 {
+    public static final int MAX_LINE_LENGTH = 450;
+
     private String connectionName;
     private String channelName;
     private Channel channel;
@@ -47,6 +49,13 @@ public class IrcEndPoint extends EndPoint
         return new EndPointInfo(connectionType, connectionName, channelName);
     }
 
+
+    @Override
+    public int getMaxMessageLength()
+    {
+        return MAX_LINE_LENGTH;
+    }
+
     @Override
     public void sendMessage(String message)
     {
@@ -60,6 +69,13 @@ public class IrcEndPoint extends EndPoint
     {
         if (!connected)
             throw new IllegalStateException("Cannot send message to disconnected EndPoint! EndPoint: " + this.toEndPointInfo().toString());
-        this.sendMessage(String.format("<%s> %s", message.getSenderName(), message.getMessage()));        
+        String[] lines = message.getMessage().split("\n");
+        for (String line : lines)
+        {
+            for (String segment : this.divideMessageForSending(line))
+            {
+                this.sendMessage(String.format("<%s> %s", message.getSenderName(), segment));
+            }
+        }
     }
 }


### PR DESCRIPTION
We now divide a message based on the max length message that an endpoint can accept.

Fixed Discord -> IRC not handling newlines correctly. Now sends a message for every line break.
Removed EndPoint.isType and replaced with EndPoint.getType
