### PR TITLE
HotFix: Fixed the .google command appending a "null" to a google search

### DIFF
--- a/src/net/dv8tion/discord/commands/SearchCommand.java
+++ b/src/net/dv8tion/discord/commands/SearchCommand.java
@@ -29,9 +29,8 @@ public class SearchCommand extends Command
 		}
 
 		GoogleSearch search = new GoogleSearch(
-		        String.format("%s+%s",
-		                StringUtils.join(splitMessage, "+", 1, splitMessage.length),
-		                filter));
+		        StringUtils.join(splitMessage, "+", 1, splitMessage.length)
+		        + ((filter != null) ? ("+" + filter) : ""));
 
 		sendMessage(e, search.getSuggestedReturn());
 	}


### PR DESCRIPTION
Fixed the .google command appending a "null" to a google search
